### PR TITLE
otel-sig-security - adding SBOM to builds

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -79,6 +79,7 @@ jobs:
     - name: Code Coverage
       run: bash <(curl -s https://codecov.io/bash) -F ${{ matrix.php-version }}
 
+    - uses: anchore/sbom-action@v0
   packages:
     uses: opentelemetry-php/gh-workflows/.github/workflows/validate-packages.yml@main
     needs: php


### PR DESCRIPTION
#otel-sig-security was asking to add SBOM to builds.  Adding it to the php GitHub action so we can ensure we have new versions.